### PR TITLE
Add dark mode / light mode toggle with persistent theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,17 @@
         --page-text: #222222;
         --page-link: #0066cc;
         --page-border: rgba(0, 0, 0, 0.12);
+        --surface-bg: #f6f8fa;
+        --surface-text: #111827;
       }
 
       html[data-theme='dark'] {
         --page-bg: #0b0f14;
         --page-text: #e6edf3;
-        --page-link: #7cb8ff;
+        --page-link: #9ad0ff;
         --page-border: rgba(255, 255, 255, 0.16);
+        --surface-bg: #111827;
+        --surface-text: #e6edf3;
       }
 
       body {
@@ -33,11 +37,60 @@
         color: var(--page-link);
       }
 
+      p,
+      li,
+      dt,
+      dd,
+      blockquote,
+      label {
+        color: var(--page-text);
+      }
+
+      pre,
+      code,
+      kbd,
+      samp {
+        background: var(--surface-bg);
+        color: var(--surface-text);
+        border-color: var(--page-border);
+      }
+
+      hr {
+        border-color: var(--page-border);
+      }
+
+      table,
+      th,
+      td {
+        border-color: var(--page-border);
+      }
+
+      input,
+      textarea,
+      select {
+        background: var(--surface-bg);
+        color: var(--surface-text);
+        border-color: var(--page-border);
+      }
+
+      ::placeholder {
+        color: color-mix(in srgb, var(--surface-text) 55%, transparent);
+      }
+
       header {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 1rem;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6 {
+        color: var(--page-text);
       }
 
       #theme-toggle {

--- a/index.html
+++ b/index.html
@@ -3,11 +3,67 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <script defer src="/_vercel/insights/script.js"></script>
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.2/new.min.css"
     />
+    <style>
+      :root {
+        --page-bg: #ffffff;
+        --page-text: #222222;
+        --page-link: #0066cc;
+        --page-border: rgba(0, 0, 0, 0.12);
+      }
+
+      html[data-theme='dark'] {
+        --page-bg: #0b0f14;
+        --page-text: #e6edf3;
+        --page-link: #7cb8ff;
+        --page-border: rgba(255, 255, 255, 0.16);
+      }
+
+      body {
+        background: var(--page-bg);
+        color: var(--page-text);
+      }
+
+      a {
+        color: var(--page-link);
+      }
+
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+      }
+
+      #theme-toggle {
+        border: 1px solid var(--page-border);
+        background: transparent;
+        color: inherit;
+        padding: 0.35rem 0.6rem;
+        border-radius: 0.5rem;
+        cursor: pointer;
+      }
+
+      #theme-toggle:focus-visible {
+        outline: 2px solid var(--page-link);
+        outline-offset: 2px;
+      }
+    </style>
+    <script>
+      (function () {
+        var stored = localStorage.getItem('theme');
+        var prefersDark =
+          window.matchMedia &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.dataset.theme = theme;
+      })();
+    </script>
     <title>Vercel HTML Starter</title>
     <meta
       name="description"
@@ -15,7 +71,32 @@
     />
   </head>
   <body>
-    <h1>Vercel HTML Starter</h1>
+    <header>
+      <h1>Vercel HTML Starter</h1>
+      <button id="theme-toggle" type="button">Toggle theme</button>
+    </header>
+    <script>
+      (function () {
+        var button = document.getElementById('theme-toggle');
+
+        function setTheme(theme) {
+          document.documentElement.dataset.theme = theme;
+          localStorage.setItem('theme', theme);
+          button.setAttribute('aria-label',
+            theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+          );
+          button.textContent = theme === 'dark' ? 'Light mode' : 'Dark mode';
+        }
+
+        var initial = document.documentElement.dataset.theme || 'light';
+        setTheme(initial);
+
+        button.addEventListener('click', function () {
+          var current = document.documentElement.dataset.theme;
+          setTheme(current === 'dark' ? 'light' : 'dark');
+        });
+      })();
+    </script>
     <p>
       This template is a simple, but powerful single
       <code>index.html</code> file deployed to


### PR DESCRIPTION
This PR adds a dark mode and light mode option to the starter template.

What changed:
- meta name="color-scheme" content="light dark" to indicate theme support.
- New CSS variables for light and dark themes and a data-theme attribute on the root element.
- Theme toggle UI: a header with a toggle button that switches between light and dark modes.
- Theme initialization and persistence: script reads a stored theme or system preference on load and applies it; toggling updates localStorage so the choice persists across sessions.
- Accessibility: the toggle updates its aria-label and focus styles for keyboard navigation.

How this solves the issue:
- Provides users with an immediate, accessible way to switch themes and have their preference remembered, improving readability and comfort in different lighting conditions.

https://cosine.sh/cosinedemo/about-cosine/task/b6hufwwqakjm
https://cosine.sh/gh/CosineDemoOrg/about-cosine/pull/2
Author: Pinal Gandhi